### PR TITLE
Added await to mongo connection

### DIFF
--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -12,7 +12,7 @@ export const revalidate = 0;
 
 export async function GET(request: Request) {
   try {
-    connectToDB();
+    await connectToDB();
 
     const products = await Product.find({}).maxTimeMS(30000).exec();
 


### PR DESCRIPTION
Added await to connectToDB() because I believe the .find() function is firing before the connection is being made during deployment. This could be the reason why the buffering timeout error is happening.