### PR TITLE
Added await to getAllProducts()

### DIFF
--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -66,13 +66,13 @@ export async function getProductById(productId: string) {
 
 export async function getAllProducts() {
   try {
-    connectToDB();
+    await connectToDB();
 
-    const products = await Product.find();
-
+    const products = await Product.find({});
+    if (!products) throw new Error('No product fetched');
     return products;
   } catch (error) {
-    console.log(error);
+    console.error('GetAllProducts failed', error);
   }
 }
 


### PR DESCRIPTION
Problem: getAllProducts() is called when loading the homepage. This function uses connectToDB() and did not have await, causing the product.find() to fire before connection was established. SImilar to the other file as well.

Solution: Added await keyword and added conditional that throws an error is connection fails.